### PR TITLE
moodle-plugin-ci on GitLab CI (extended)

### DIFF
--- a/.gitlab-ci.dist.yml
+++ b/.gitlab-ci.dist.yml
@@ -1,0 +1,50 @@
+image: php:5.6
+
+services:
+ - mysql:latest
+
+cache:
+ paths:
+ - $HOME/.composer/cache
+
+variables:
+ MOODLE_BRANCH: "MOODLE_29_STABLE"
+ DB: "mysqli"
+ MYSQL_ROOT_PASSWORD: "superrootpass"
+ TRAVIS_BUILD_DIR: "$CI_PROJECT_DIR"
+
+before_script:
+ # Several tools complain about xdebug slowdown.
+ #- phpenv config-rm xdebug.ini
+ # Install php-gd
+ - apt-get update
+ - apt-get install -y git libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev libicu-dev g++ mysql-client php5-mysql npm
+ - docker-php-ext-install -j$(nproc) iconv mcrypt intl zip mysqli
+ - docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+ - docker-php-ext-install -j$(nproc) gd
+ # Install phpunit.
+ - curl -o /usr/local/bin/phpunit https://phar.phpunit.de/phpunit.phar
+ - chmod +x /usr/local/bin/phpunit
+ - cd ../..
+ # Install composer.
+ - curl -sS https://getcomposer.org/installer | php
+ - mv composer.phar /usr/local/bin/composer
+ - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+ - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+ - chmod u+x /builds/ci/bin/moodle-plugin-ci
+ - chmod u+x /builds/ci/bin/*
+ - umask u+x
+ - moodle-plugin-ci install --db-user=root --db-pass=superrootpass --db-host=mysql -vvv
+
+job1:
+ script:
+ - moodle-plugin-ci phplint
+ - moodle-plugin-ci phpcpd
+ - moodle-plugin-ci phpmd
+ - moodle-plugin-ci codechecker
+ - moodle-plugin-ci csslint
+ - moodle-plugin-ci shifter
+ - moodle-plugin-ci jshint
+ - moodle-plugin-ci validate
+ - moodle-plugin-ci phpunit
+ - moodle-plugin-ci behat

--- a/.gitlab-ci.dist.yml
+++ b/.gitlab-ci.dist.yml
@@ -14,11 +14,10 @@ variables:
  TRAVIS_BUILD_DIR: "$CI_PROJECT_DIR"
 
 before_script:
- # Several tools complain about xdebug slowdown.
- #- phpenv config-rm xdebug.ini
  # Install php-gd
  - apt-get update
  - apt-get install -y git libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev libicu-dev g++ mysql-client php5-mysql npm
+ - ln -s "$(which nodejs)" /usr/bin/node
  - docker-php-ext-install -j$(nproc) iconv mcrypt intl zip mysqli
  - docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
  - docker-php-ext-install -j$(nproc) gd

--- a/.gitlab-ci.dist.yml
+++ b/.gitlab-ci.dist.yml
@@ -1,5 +1,3 @@
-image: php:5.6
-
 services:
  - mysql:latest
 
@@ -8,7 +6,6 @@ cache:
  - $HOME/.composer/cache
 
 variables:
- MOODLE_BRANCH: "MOODLE_29_STABLE"
  DB: "mysqli"
  MYSQL_ROOT_PASSWORD: "superrootpass"
  TRAVIS_BUILD_DIR: "$CI_PROJECT_DIR"
@@ -35,15 +32,21 @@ before_script:
  - umask u+x
  - moodle-plugin-ci install --db-user=root --db-pass=superrootpass --db-host=mysql -vvv
 
-job1:
+.job_template: &job_definition
  script:
- - moodle-plugin-ci phplint
- - moodle-plugin-ci phpcpd
- - moodle-plugin-ci phpmd
- - moodle-plugin-ci codechecker
- - moodle-plugin-ci csslint
- - moodle-plugin-ci shifter
- - moodle-plugin-ci jshint
- - moodle-plugin-ci validate
- - moodle-plugin-ci phpunit
- - moodle-plugin-ci behat
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat
+
+job1:
+ <<: *job_definition
+ image: php:7.0
+ variables:
+  MOODLE_BRANCH: "MOODLE_32_STABLE"


### PR DESCRIPTION
Hi, I have applied the awesome idea of @danielneis (#15) to my own projects and found it very useful. I have modified the config in the following ways:

* Enable matrix builds by specifying a default job template (`job_template`) from which builds can inherit. Builds can then specify their respective PHP versions and Moodle branches.
* Created a symbolic link `node` to the `nodejs` binary, since `csslint` expects to be able to call `node`.
* Removed the `phpenv` to remove xdebug, as it did not work out for me.

Sorry for creating an additional pull request; I was unable to modify @danielneis's branch myself. Branched from his commit, though :)