### PR TITLE
Set password for postgres via envionment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-No unreleased changes.
+### Changed
+- Set password via environment when connecting with Postgres.
 
 ## [2.0.1] - 2017-06-07
 ### Fixed

--- a/src/Installer/Database/PostgresDatabase.php
+++ b/src/Installer/Database/PostgresDatabase.php
@@ -22,10 +22,11 @@ class PostgresDatabase extends AbstractDatabase
 
     public function getCreateDatabaseCommand()
     {
+        $pass     = !empty($this->pass) ? 'env PGPASSWORD='.escapeshellarg($this->pass).' ' : '';
         $user     = escapeshellarg($this->user);
         $host     = escapeshellarg($this->host);
         $createDB = escapeshellarg(sprintf('CREATE DATABASE "%s";', $this->name));
 
-        return sprintf('psql -c %s -U %s -h %s', $createDB, $user, $host);
+        return sprintf('%spsql -c %s -U %s -h %s', $pass, $createDB, $user, $host);
     }
 }

--- a/tests/Installer/Database/PostgresDatabaseTest.php
+++ b/tests/Installer/Database/PostgresDatabaseTest.php
@@ -24,7 +24,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
         $database->pass = 'TestPass';
         $database->host = 'TestHost';
 
-        $expected = 'psql -c \'CREATE DATABASE "TestName";\' -U \'TestUser\' -h \'TestHost\'';
+        $expected = 'env PGPASSWORD=\'TestPass\' psql -c \'CREATE DATABASE "TestName";\' -U \'TestUser\' -h \'TestHost\'';
         $this->assertSame($expected, $database->getCreateDatabaseCommand());
     }
 }


### PR DESCRIPTION
Without this change, the user is prompted to type in the password when
the tool needs to send commands to the postgres database if the role
used to connect is set to require a password.