### PR TITLE
Fix #60: Enforce assignments to `$string` in LangFinder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-No unreleased changes.
+### Fixed
+- `moodle-plugin-ci validate` now only regards required language strings as present if they are assigned to the `$string` array. Before, other array variables were accepted although Moodle would not recognise them.  
 
 ## [2.1.1]
 ### Fixed

--- a/src/PluginValidate/Finder/LangFinder.php
+++ b/src/PluginValidate/Finder/LangFinder.php
@@ -13,6 +13,7 @@
 namespace Moodlerooms\MoodlePluginCI\PluginValidate\Finder;
 
 use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 
 /**
@@ -32,6 +33,11 @@ class LangFinder extends AbstractParserFinder
         foreach ($this->filter->filterAssignments($statements) as $assign) {
             // Looking for a assignment to an array key, EG: $string['something'].
             if ($assign->var instanceof ArrayDimFetch) {
+                // Verify that the array name is $string.
+                $arrayName = $assign->var->var;
+                if (!($arrayName instanceof Variable) || $arrayName->name !== 'string') {
+                    continue;
+                }
                 // Grab the array index.
                 $arrayIndex = $assign->var->dim;
                 if ($arrayIndex instanceof String_) {


### PR DESCRIPTION
The issue identified in #60 is correct, as per https://docs.moodle.org/dev/String_API#Adding_a_string_to_the_language_file. 
I have created a small fix that enforces the array name to be `$string`. More precisely, it can be of any other name, but then it does not count as a language string.

Checks out against the current tests. Also, out of curiosity (as I am not familiar with the parser) I have introspected type and contents of `$assign->var->var`, and this seems to be correct.