### PR TITLE
Fix paths in contribution guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,4 @@ Ways to improve your chances of getting your contribution accepted:
 * Only one pull request per feature or fix.
 * Send coherent history by making sure each individual commit in your pull request is meaningful. Use interactive
   rebase to squash intermediate commits.
-* Ensure that [read me](README.md), [change log](CHANGELOG.md) and [other docs](doc) are updated as needed.
+* Ensure that [read me](README.md), [change log](docs/CHANGELOG.md) and [other docs](docs/) are updated as needed.


### PR DESCRIPTION
https://github.com/moodlerooms/moodle-plugin-ci/blob/master/CONTRIBUTING.md (https://github.com/moodlerooms/moodle-plugin-ci/blob/86a6a89a0ba988ab7db87657aeb2143aa45bbef0/CONTRIBUTING.md) contains wrong links to docs and changelog. This is why, at first, I didn't update the changelog for my commit #63  (thinking that there isn't any). Then I found it by chance, changed my commit and thought that it might be useful for others to just fix the CONTRIBUTING.md as well :smiley: .