### PR TITLE
Fix #65: Provide optional argument for `install` to skip DB installation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 ### Fixed
 - `moodle-plugin-ci validate` now only regards required language strings as present if they are assigned to the `$string` array. Before, other array variables were accepted although Moodle would not recognise them.  
+- `moodle-plugin-ci install` now provides an option `--skip-db-install` to skip DB installation if execution of unit tests and behat test will not be required.
 
 ## [2.1.1]
 ### Fixed

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -87,7 +87,8 @@ class InstallCommand extends Command
             ->addOption('db-host', null, InputOption::VALUE_REQUIRED, 'Database host', 'localhost')
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
-            ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra);
+            ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
+            ->addOption('skip-db-install', null, InputOption::VALUE_REQUIRED, 'Skip DB installation, e.g. if only static analyses are required', false);
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -163,6 +164,7 @@ class InstallCommand extends Command
             $input->getOption('db-pass'),
             $input->getOption('db-host')
         );
+        $factory->skipDbInstall = $input->getOption('skip-db-install');
 
         return $factory;
     }

--- a/src/Installer/InstallerFactory.php
+++ b/src/Installer/InstallerFactory.php
@@ -69,6 +69,11 @@ class InstallerFactory
     public $pluginsDir;
 
     /**
+     * @var bool
+     */
+    public $skipDbInstall;
+
+    /**
      * Given a big bag of install options, add installers to the collection.
      *
      * @param InstallerCollection $installers Installers will be added to this
@@ -79,7 +84,9 @@ class InstallerFactory
         $installers->add(new PluginInstaller($this->moodle, $this->plugin, $this->pluginsDir, $this->dumper));
         $installers->add(new VendorInstaller($this->moodle, $this->plugin, $this->execute));
 
-        if ($this->plugin->hasBehatFeatures() || $this->plugin->hasUnitTests()) {
+        if ($this->skipDbInstall) {
+            return;
+        } elseif ($this->plugin->hasBehatFeatures() || $this->plugin->hasUnitTests()) {
             $installers->add(new TestSuiteInstaller($this->moodle, $this->plugin, $this->execute));
         }
     }


### PR DESCRIPTION
This adds the option to pass `--skip-db-install` to the `install` command, causing the `InstallerFactory` to omit core/plugin installation.

Sorry, I have no idea on how to test this properly, given that I'd need to test the **absence** of an installed DB... If you have any idea, feel free to suggest / add to this branch.

Either way, the existing workflow is not broken, as confirmed by your existing tests.

Cheers!