### PR TITLE
.travis.dist.yml: Use Travis build stages when configuring your build

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -22,7 +22,7 @@ php:
 
 env:
  global:
-  - MOODLE_BRANCH=MOODLE_32_STABLE
+  - MOODLE_BRANCH=MOODLE_34_STABLE
  matrix:
   - DB=pgsql
   - DB=mysqli
@@ -35,17 +35,32 @@ before_install:
   - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
+jobs:
+  include:
+    # Prechecks against one configuration (Moodle, PHP, DB) only.
+    - stage: prechecks
+      php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+      install:
+      - moodle-plugin-ci install --no-init
+      script:
+      - moodle-plugin-ci phplint
+      - moodle-plugin-ci phpcpd
+      - moodle-plugin-ci phpmd
+      - moodle-plugin-ci codechecker
+      - moodle-plugin-ci validate
+      - moodle-plugin-ci savepoints
+      - moodle-plugin-ci mustache
+      - moodle-plugin-ci grunt
+
+# Unit tests and behat tests against full matrix (Implicit "test" stage).
 install:
   - moodle-plugin-ci install
 
 script:
-  - moodle-plugin-ci phplint
-  - moodle-plugin-ci phpcpd
-  - moodle-plugin-ci phpmd
-  - moodle-plugin-ci codechecker
-  - moodle-plugin-ci validate
-  - moodle-plugin-ci savepoints
-  - moodle-plugin-ci mustache
-  - moodle-plugin-ci grunt
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat
+
+stages:
+- prechecks
+- test


### PR DESCRIPTION
Thanks again for having merged the `--no-init` option in #66. We have been successfully able to leverage it to use build stages in our projects (https://travis-ci.org/learnweb/moodle-repository_owncloud/builds/334743893, https://travis-ci.org/learnweb/moodle-mod_collaborativefolders/builds/328301352) and it's very useful. 

Here's how the `.travis.yml` needs to be configured to make use of that option in combination with build stages.
