### PR TITLE
Add mariadb support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ jobs:
       env: MOODLE_BRANCH=MOODLE_33_STABLE
     - php: 5.6
       env: MOODLE_BRANCH=MOODLE_32_STABLE DB=mysqli PROFILE=default
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=mariadb
+      addons:
+        mariadb: 10.2
     - stage: Deploy
       addons: skip
       install: skip

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -80,7 +80,7 @@ class InstallCommand extends Command
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Moodle repository to clone', $repo)
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Moodle git branch to clone, EG: MOODLE_29_STABLE', $branch)
             ->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'Path to Moodle plugin', $plugin)
-            ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli or pgsql', $type)
+            ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli, pgsql or mariadb', $type)
             ->addOption('db-user', null, InputOption::VALUE_REQUIRED, 'Database user')
             ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', '')
             ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', 'moodle')

--- a/src/Installer/Database/DatabaseResolver.php
+++ b/src/Installer/Database/DatabaseResolver.php
@@ -60,7 +60,7 @@ class DatabaseResolver
                 return $database;
             }
         }
-        throw new \DomainException(sprintf('Unknown database type (%s). Please use mysqli or pgsql.', $type));
+        throw new \DomainException(sprintf('Unknown database type (%s). Please use mysqli, pgsql or mariadb.', $type));
     }
 
     /**
@@ -68,6 +68,6 @@ class DatabaseResolver
      */
     private function getDatabases()
     {
-        return [new MySQLDatabase(), new PostgresDatabase()];
+        return [new MySQLDatabase(), new PostgresDatabase(), new MariaDBDatabase()];
     }
 }

--- a/src/Installer/Database/MariaDBDatabase.php
+++ b/src/Installer/Database/MariaDBDatabase.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moodlerooms\MoodlePluginCI\Installer\Database;
+
+/**
+ * MariaDB Database.
+ * Since it should be pretty like mysql, it is probably fine to just inherit everything from MySQLDatabase and only change the type.
+ */
+class MariaDBDatabase extends MySQLDatabase
+{
+    public $type = 'mariadb';
+}

--- a/tests/Installer/Database/DatabaseResolverTest.php
+++ b/tests/Installer/Database/DatabaseResolverTest.php
@@ -28,6 +28,10 @@ class DatabaseResolverTest extends \PHPUnit_Framework_TestCase
             'Moodlerooms\MoodlePluginCI\Installer\Database\PostgresDatabase',
             $resolver->resolveDatabase('pgsql')
         );
+        $this->assertInstanceOf(
+            'Moodlerooms\MoodlePluginCI\Installer\Database\MariaDBDatabase',
+            $resolver->resolveDatabase('mariadb')
+        );
     }
 
     public function testTypeError()

--- a/tests/Installer/Database/MariaDBDatabaseTest.php
+++ b/tests/Installer/Database/MariaDBDatabaseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moodlerooms\MoodlePluginCI\Tests\Installer\Database;
+
+use Moodlerooms\MoodlePluginCI\Installer\Database\MariaDBDatabase;
+
+class MariaDBDatabaseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetCreateDatabaseCommand()
+    {
+        $database       = new MariaDBDatabase();
+        $database->name = 'TestName';
+        $database->user = 'TestUser';
+        $database->pass = 'TestPass';
+        $database->host = 'TestHost';
+
+        $expected = 'mysql -u \'TestUser\' --password=\'TestPass\' -h \'TestHost\' -e \'CREATE DATABASE `TestName` DEFAULT CHARACTER SET UTF8 COLLATE utf8_general_ci;\'';
+        $this->assertSame($expected, $database->getCreateDatabaseCommand());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/moodlerooms/moodle-plugin-ci/issues/76

I don't know how I can try this on my real moodle plugin without having to PR first. Im not good at travis, so seeking help with documentation and how to describe it best (and what's correct at all). For mariadb to work, it seems we have to use the addons functionality in the matrix inside a include: (e.g. .travis.yml:78)
```
    - php: 7.1
      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=mariadb
      addons:
        mariadb: 10.2
```

In the simple matrix as described in the travis dist file (.travis.dist.yml:26) we seem so be unable to add the addons information to that list, as it is a list of strings it seems
```
 matrix:
  - DB=pgsql
  - DB=mysqli
#following doesnt work
  - DB=mariadb
    addons:
      mariadb: 10.2
```

So that means, and If above is correct, we can't describe how to use mariadb with the existing example travis file...