### PR TITLE
Use openjdk-8-jre-headless instead of oracle-java8.

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -7,8 +7,7 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
       - chromium-chromedriver
 
 cache:
@@ -80,8 +79,7 @@ jobs:
         mariadb: 10.2
         apt:
           packages:
-            - oracle-java8-installer
-            - oracle-java8-set-default
+            - openjdk-8-jre-headless
             - chromium-chromedriver
     - php: 5.6
       env: MOODLE_BRANCH=MOODLE_32_STABLE DB=mysqli PROFILE=default

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -23,8 +23,7 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 # Cache NPM's and Composer's caches to speed up build times.
 cache:


### PR DESCRIPTION
Fixes #83.