### PR TITLE
Bump moodle-local_codechecker to 2.9.2 (2.9.3 in fact)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_codechecker",
-        "version": "2.7.1",
+        "version": "2.9.3",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
           "type": "git",
-          "reference": "v2.7.1"
+          "reference": "v2.9.3"
         },
         "autoload": {
           "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c48ab1514c8de874ab9327c951daaf3",
+    "content-hash": "f624eb46eac1e9a4ce3e448d3a809af3",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -255,11 +255,11 @@
         },
         {
             "name": "moodlehq/moodle-local_codechecker",
-            "version": "2.7.1",
+            "version": "2.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-                "reference": "v2.7.1"
+                "reference": "v2.9.3"
             },
             "type": "library",
             "autoload": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - Add `moodle-plugin-ci phpdoc` check which executes
   [moodlehq/moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck.git)
   on the plugin.
+- Updated project dependencies: Moodle Code Checker v2.9.3 (added PHP 7.3 support)
 
 ## [2.4.0] - 2018-09-11
 ### Changed


### PR DESCRIPTION
This is important for PHP 7.3 support. Please refer to moodle-local_codechecker changelog for more details: https://github.com/moodlehq/moodle-local_codechecker/blob/master/CHANGES.md