### PR TITLE
Add option --suite to behat job

### DIFF
--- a/src/Command/BehatCommand.php
+++ b/src/Command/BehatCommand.php
@@ -46,6 +46,7 @@ class BehatCommand extends AbstractMoodleCommand
 
         $this->setName('behat')
             ->addOption('profile', 'p', InputOption::VALUE_REQUIRED, 'Behat profile to use', 'default')
+            ->addOption('suite', null, InputOption::VALUE_REQUIRED, 'Behat suite to use (Moodle theme)', 'default')
             ->addOption('start-servers', null, InputOption::VALUE_NONE, 'Start Selenium and PHP servers')
             ->addOption('jar', null, InputOption::VALUE_REQUIRED, 'Path to Selenium Jar file', $jar)
             ->addOption('auto-rerun', null, InputOption::VALUE_REQUIRED, 'Number of times to rerun failures', 2)
@@ -79,6 +80,7 @@ class BehatCommand extends AbstractMoodleCommand
             ->add('admin/tool/behat/cli/run.php')
             ->add('--tags=@'.$this->plugin->getComponent())
             ->add('--profile='.$input->getOption('profile'))
+            ->add('--suite='.$input->getOption('suite'))
             ->add('--auto-rerun='.$input->getOption('auto-rerun'))
             ->add('--verbose')
             ->add('-vvv')

--- a/src/Installer/TestSuiteInstaller.php
+++ b/src/Installer/TestSuiteInstaller.php
@@ -143,7 +143,7 @@ class TestSuiteInstaller extends AbstractInstaller
 
         if ($this->plugin->hasBehatFeatures()) {
             $this->getOutput()->debug('Enabling Behat');
-            $processes[] = new MoodleProcess(sprintf('%s --enable', $this->getBehatUtility()));
+            $processes[] = new MoodleProcess(sprintf('%s --enable --add-core-features-to-theme', $this->getBehatUtility()));
         }
         if ($this->plugin->hasUnitTests()) {
             $this->getOutput()->debug('Build PHPUnit config');


### PR DESCRIPTION
After https://tracker.moodle.org/browse/MDL-63607 (integrated in the 3.7dev) it is no longer possible to add "$CFG->theme=..." to the config.php in order to run behat tests on a specific theme. Now behat job on travis needs to allow to switch between themes.

Initialise all themes in behat by using --add-core-features-to-theme
Allow to specify --suite option for behat job, if not specified, use
default suite (default theme)