### PR TITLE
Missing behat --suite option in docs and changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ No unreleased changes.
 - Add `moodle-plugin-ci phpdoc` check which executes
   [moodlehq/moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck)
   on the plugin.
+- `moodle-plugin-ci behat` now provides an option `--suite` to define the
+  theme to use while running the test.
 
 ## [2.4.0] - 2018-09-11
 ### Changed

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -126,5 +126,7 @@ script:
 #     default is 2, EG usage: --auto-rerun 3
 #   - The dump option allows you to print the failure HTML to the console,
 #     handy for debugging, EG usage: --dump
+#   - The suite option allows you to set the theme to use for behat test. If
+#     not specified, the default theme is used, EG usage: --suite boost
   - moodle-plugin-ci behat
 ```


### PR DESCRIPTION
Apparently, it got released without any reference in docs/changelog.