### PR TITLE
Ability to use the moodle-plugin-ci inside a existing Moodle repository

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -795,7 +795,7 @@ Install everything required for CI testing
 
 ### Usage
 
-* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init]`
+* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--no-clone]`
 
 Install everything required for CI testing
 
@@ -921,6 +921,15 @@ Directory of extra plugins to install
 #### `--no-init`
 
 Prevent PHPUnit and Behat initialization
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-clone`
+
+Prevent Cloning Moodle from an external repository but consider it already installed with plugins.
 
 * Accept value: no
 * Is value required: no

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -929,7 +929,7 @@ Prevent PHPUnit and Behat initialization
 
 #### `--no-clone`
 
-Prevent Cloning Moodle from an external repository but consider it already installed with plugins.
+Prevent Cloning Moodle
 
 * Accept value: no
 * Is value required: no

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -795,7 +795,7 @@ Install everything required for CI testing
 
 ### Usage
 
-* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--no-clone]`
+* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--db-create-skip] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--no-clone]`
 
 Install everything required for CI testing
 
@@ -890,6 +890,15 @@ Database host
 * Is value required: yes
 * Is multiple: no
 * Default: `'localhost'`
+
+#### `--db-create-skip`
+
+Skip database creation
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
 
 #### `--not-paths`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -795,7 +795,7 @@ Install everything required for CI testing
 
 ### Usage
 
-* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--db-create-skip] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--no-clone]`
+* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--db-create-skip] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--no-clone] [--no-config-rewrite]`
 
 Install everything required for CI testing
 
@@ -939,6 +939,15 @@ Prevent PHPUnit and Behat initialization
 #### `--no-clone`
 
 Prevent Cloning Moodle
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-config-rewrite`
+
+Prevent generating a new Moodle config.php file
 
 * Accept value: no
 * Is value required: no

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -89,6 +89,7 @@ class InstallCommand extends Command
             ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', '')
             ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', 'moodle')
             ->addOption('db-host', null, InputOption::VALUE_REQUIRED, 'Database host', 'localhost')
+            ->addOption('db-create-skip', null, InputOption::VALUE_NONE, 'Skip database creation')
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
@@ -153,10 +154,11 @@ class InstallCommand extends Command
             $pluginsDir = realpath($validate->directory($pluginsDir));
         }
 
-        $factory          = new InstallerFactory();
-        $factory->moodle  = new Moodle($input->getOption('moodle'));
-        $factory->plugin  = new MoodlePlugin($pluginDir);
-        $factory->execute = $this->execute;
+        $factory           = new InstallerFactory();
+        $factory->moodle   = new Moodle($input->getOption('moodle'));
+        $factory->plugin   = new MoodlePlugin($pluginDir);
+        $factory->execute  = $this->execute;
+        $factory->createDb = !$input->getOption('db-create-skip');
         if (!$input->getOption('no-clone')) {
             $factory->repo   = $validate->gitUrl($input->getOption('repo'));
             $factory->branch = $validate->gitBranch($input->getOption('branch'));

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -93,7 +93,8 @@ class InstallCommand extends Command
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
             ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization')
-            ->addOption('no-clone', null, InputOption::VALUE_NONE, 'Prevent Cloning Moodle');
+            ->addOption('no-clone', null, InputOption::VALUE_NONE, 'Prevent Cloning Moodle')
+            ->addOption('no-config-rewrite', null, InputOption::VALUE_NONE, 'Prevent generating a new Moodle config.php file');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -168,11 +169,12 @@ class InstallCommand extends Command
             $factory->pluginDir = $pluginDir;
         }
 
-        $factory->dataDir    = $input->getOption('data');
-        $factory->dumper     = $this->initializePluginConfigDumper($input);
-        $factory->pluginsDir = $pluginsDir;
-        $factory->noInit     = $input->getOption('no-init');
-        $factory->database   = $resolver->resolveDatabase(
+        $factory->dataDir             = $input->getOption('data');
+        $factory->dumper              = $this->initializePluginConfigDumper($input);
+        $factory->pluginsDir          = $pluginsDir;
+        $factory->noInit              = $input->getOption('no-init');
+        $factory->noConfigRewrite     = (bool) $input->getOption('no-config-rewrite');
+        $factory->database            = $resolver->resolveDatabase(
             $input->getOption('db-type'),
             $input->getOption('db-name'),
             $input->getOption('db-user'),

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -13,7 +13,6 @@
 namespace MoodlePluginCI\Command;
 
 use MoodlePluginCI\Bridge\Moodle;
-use MoodlePluginCI\Bridge\MoodlePlugin;
 use MoodlePluginCI\Installer\ConfigDumper;
 use MoodlePluginCI\Installer\Database\DatabaseResolver;
 use MoodlePluginCI\Installer\EnvDumper;
@@ -68,14 +67,14 @@ class InstallCommand extends Command
     protected function configure()
     {
         // Travis CI configures some things by environment variables, default to those if available.
-        $type    = getenv('DB') !== false ? getenv('DB') : null;
-        $repo    = getenv('MOODLE_REPO') !== false ? getenv('MOODLE_REPO') : 'git://github.com/moodle/moodle.git';
-        $branch  = getenv('MOODLE_BRANCH') !== false ? getenv('MOODLE_BRANCH') : null;
-        $plugin  = getenv('TRAVIS_BUILD_DIR') !== false ? getenv('TRAVIS_BUILD_DIR') : null;
-        $paths   = getenv('IGNORE_PATHS') !== false ? getenv('IGNORE_PATHS') : null;
-        $names   = getenv('IGNORE_NAMES') !== false ? getenv('IGNORE_NAMES') : null;
-        $extra   = getenv('EXTRA_PLUGINS_DIR') !== false ? getenv('EXTRA_PLUGINS_DIR') : null;
-        $moodle  = getenv('MOODLE_DIR') !== false ? getenv('MOODLE_DIR') : 'moodle';
+        $type   = getenv('DB') !== false ? getenv('DB') : null;
+        $repo   = getenv('MOODLE_REPO') !== false ? getenv('MOODLE_REPO') : 'git://github.com/moodle/moodle.git';
+        $branch = getenv('MOODLE_BRANCH') !== false ? getenv('MOODLE_BRANCH') : null;
+        $plugin = getenv('TRAVIS_BUILD_DIR') !== false ? getenv('TRAVIS_BUILD_DIR') : null;
+        $paths  = getenv('IGNORE_PATHS') !== false ? getenv('IGNORE_PATHS') : null;
+        $names  = getenv('IGNORE_NAMES') !== false ? getenv('IGNORE_NAMES') : null;
+        $extra  = getenv('EXTRA_PLUGINS_DIR') !== false ? getenv('EXTRA_PLUGINS_DIR') : null;
+        $moodle = getenv('MOODLE_DIR') !== false ? getenv('MOODLE_DIR') : 'moodle';
 
         $this->setName('install')
             ->setDescription('Install everything required for CI testing')
@@ -154,22 +153,26 @@ class InstallCommand extends Command
             $pluginsDir = realpath($validate->directory($pluginsDir));
         }
 
-        $factory           = new InstallerFactory();
-        $factory->moodle   = new Moodle($input->getOption('moodle'));
-        $factory->plugin   = new MoodlePlugin($pluginDir);
-        $factory->execute  = $this->execute;
-        $factory->createDb = !$input->getOption('db-create-skip');
+        $factory                    = new InstallerFactory();
+        $factory->moodle            = new Moodle($input->getOption('moodle'));
+        $factory->execute           = $this->execute;
+        $factory->createDb          = !$input->getOption('db-create-skip');
+        $factory->plugininmoodledir = (bool) $input->getOption('no-clone');
+
         if (!$input->getOption('no-clone')) {
             $factory->repo   = $validate->gitUrl($input->getOption('repo'));
             $factory->branch = $validate->gitBranch($input->getOption('branch'));
         }
 
-        $factory->dataDir           = $input->getOption('data');
-        $factory->dumper            = $this->initializePluginConfigDumper($input);
-        $factory->pluginsDir        = $pluginsDir;
-        $factory->noInit            = $input->getOption('no-init');
-        $factory->plugininmoodledir = (bool) $input->getOption('no-clone');
-        $factory->database          = $resolver->resolveDatabase(
+        if (!$factory->plugininmoodledir) {
+            $factory->pluginDir = $pluginDir;
+        }
+
+        $factory->dataDir    = $input->getOption('data');
+        $factory->dumper     = $this->initializePluginConfigDumper($input);
+        $factory->pluginsDir = $pluginsDir;
+        $factory->noInit     = $input->getOption('no-init');
+        $factory->database   = $resolver->resolveDatabase(
             $input->getOption('db-type'),
             $input->getOption('db-name'),
             $input->getOption('db-user'),

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -91,7 +91,8 @@ class InstallCommand extends Command
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
-            ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization');
+            ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization')
+            ->addOption('no-clone', null, InputOption::VALUE_NONE, 'Prevent Cloning Moodle');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -151,17 +152,21 @@ class InstallCommand extends Command
             $pluginsDir = realpath($validate->directory($pluginsDir));
         }
 
-        $factory             = new InstallerFactory();
-        $factory->moodle     = new Moodle($input->getOption('moodle'));
-        $factory->plugin     = new MoodlePlugin($pluginDir);
-        $factory->execute    = $this->execute;
-        $factory->repo       = $validate->gitUrl($input->getOption('repo'));
-        $factory->branch     = $validate->gitBranch($input->getOption('branch'));
-        $factory->dataDir    = $input->getOption('data');
-        $factory->dumper     = $this->initializePluginConfigDumper($input);
-        $factory->pluginsDir = $pluginsDir;
-        $factory->noInit     = $input->getOption('no-init');
-        $factory->database   = $resolver->resolveDatabase(
+        $factory          = new InstallerFactory();
+        $factory->moodle  = new Moodle($input->getOption('moodle'));
+        $factory->plugin  = new MoodlePlugin($pluginDir);
+        $factory->execute = $this->execute;
+        if (!$input->getOption('no-clone')) {
+            $factory->repo   = $validate->gitUrl($input->getOption('repo'));
+            $factory->branch = $validate->gitBranch($input->getOption('branch'));
+        }
+
+        $factory->dataDir           = $input->getOption('data');
+        $factory->dumper            = $this->initializePluginConfigDumper($input);
+        $factory->pluginsDir        = $pluginsDir;
+        $factory->noInit            = $input->getOption('no-init');
+        $factory->plugininmoodledir = (bool) $input->getOption('no-clone');
+        $factory->database          = $resolver->resolveDatabase(
             $input->getOption('db-type'),
             $input->getOption('db-name'),
             $input->getOption('db-user'),

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -68,17 +68,18 @@ class InstallCommand extends Command
     protected function configure()
     {
         // Travis CI configures some things by environment variables, default to those if available.
-        $type   = getenv('DB') !== false ? getenv('DB') : null;
-        $repo   = getenv('MOODLE_REPO') !== false ? getenv('MOODLE_REPO') : 'git://github.com/moodle/moodle.git';
-        $branch = getenv('MOODLE_BRANCH') !== false ? getenv('MOODLE_BRANCH') : null;
-        $plugin = getenv('TRAVIS_BUILD_DIR') !== false ? getenv('TRAVIS_BUILD_DIR') : null;
-        $paths  = getenv('IGNORE_PATHS') !== false ? getenv('IGNORE_PATHS') : null;
-        $names  = getenv('IGNORE_NAMES') !== false ? getenv('IGNORE_NAMES') : null;
-        $extra  = getenv('EXTRA_PLUGINS_DIR') !== false ? getenv('EXTRA_PLUGINS_DIR') : null;
+        $type    = getenv('DB') !== false ? getenv('DB') : null;
+        $repo    = getenv('MOODLE_REPO') !== false ? getenv('MOODLE_REPO') : 'git://github.com/moodle/moodle.git';
+        $branch  = getenv('MOODLE_BRANCH') !== false ? getenv('MOODLE_BRANCH') : null;
+        $plugin  = getenv('TRAVIS_BUILD_DIR') !== false ? getenv('TRAVIS_BUILD_DIR') : null;
+        $paths   = getenv('IGNORE_PATHS') !== false ? getenv('IGNORE_PATHS') : null;
+        $names   = getenv('IGNORE_NAMES') !== false ? getenv('IGNORE_NAMES') : null;
+        $extra   = getenv('EXTRA_PLUGINS_DIR') !== false ? getenv('EXTRA_PLUGINS_DIR') : null;
+        $moodle  = getenv('MOODLE_DIR') !== false ? getenv('MOODLE_DIR') : 'moodle';
 
         $this->setName('install')
             ->setDescription('Install everything required for CI testing')
-            ->addOption('moodle', null, InputOption::VALUE_REQUIRED, 'Clone Moodle to this directory', 'moodle')
+            ->addOption('moodle', null, InputOption::VALUE_REQUIRED, 'Clone Moodle to this directory', $moodle)
             ->addOption('data', null, InputOption::VALUE_REQUIRED, 'Directory create for Moodle data files', 'moodledata')
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Moodle repository to clone', $repo)
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Moodle git branch to clone, EG: MOODLE_29_STABLE', $branch)

--- a/src/Installer/AbstractPluginInstaller.php
+++ b/src/Installer/AbstractPluginInstaller.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Installer;
+
+use MoodlePluginCI\Bridge\MoodlePlugin;
+
+abstract class AbstractPluginInstaller extends AbstractInstaller
+{
+    /**
+     * The list of plugins that are installed and should be prepared for unit testing.
+     *
+     * @return MoodlePlugin[]
+     */
+    abstract public function pluginsToPrepare();
+}

--- a/src/Installer/InstallOutput.php
+++ b/src/Installer/InstallOutput.php
@@ -13,12 +13,13 @@
 namespace MoodlePluginCI\Installer;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Console\Helper\ProgressBar;
 
 /**
  * Handles output for installation process.
  */
-class InstallOutput
+class InstallOutput implements LoggerInterface
 {
     /**
      * @var ProgressBar|null
@@ -106,28 +107,76 @@ class InstallOutput
     }
 
     /**
-     * Log a message, shown in lower verbosity mode.
-     *
-     * @param string $message
-     * @param array  $context
+     * {@inheritdoc}
      */
     public function info($message, array $context = [])
     {
-        if ($this->logger instanceof LoggerInterface) {
-            $this->logger->info($message, $context);
-        }
+        $this->log(LogLevel::INFO, $message, $context);
     }
 
     /**
-     * Log a message, shown in highest verbosity mode.
-     *
-     * @param string $message
-     * @param array  $context
+     * {@inheritdoc}
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function debug($message, array $context = [])
     {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function emergency($message, array $context = [])
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = [])
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = [])
+    {
         if ($this->logger instanceof LoggerInterface) {
-            $this->logger->debug($message, $context);
+            $this->logger->log($level, $message, $context);
         }
     }
 }

--- a/src/Installer/InstallerFactory.php
+++ b/src/Installer/InstallerFactory.php
@@ -88,13 +88,18 @@ class InstallerFactory
     public $plugininmoodledir;
 
     /**
+     * @var bool if true, the plugins are not copied into Moodle directory
+     */
+    public $noConfigRewrite;
+
+    /**
      * Given a big bag of install options, add installers to the collection.
      *
      * @param InstallerCollection $installers Installers will be added to this
      */
     public function addInstallers(InstallerCollection $installers)
     {
-        $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir, $this->createDb));
+        $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir, $this->createDb, !$this->noConfigRewrite));
         $installer = $this->getPluginInstaller();
         $plugins   = $installer->pluginsToPrepare();
 

--- a/src/Installer/InstallerFactory.php
+++ b/src/Installer/InstallerFactory.php
@@ -74,6 +74,11 @@ class InstallerFactory
     public $noInit;
 
     /**
+     * @var bool
+     */
+    public $plugininmoodledir;
+
+    /**
      * Given a big bag of install options, add installers to the collection.
      *
      * @param InstallerCollection $installers Installers will be added to this
@@ -81,7 +86,7 @@ class InstallerFactory
     public function addInstallers(InstallerCollection $installers)
     {
         $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir));
-        $installers->add(new PluginInstaller($this->moodle, $this->plugin, $this->pluginsDir, $this->dumper));
+        $installers->add(new PluginInstaller($this->moodle, $this->plugin, $this->pluginsDir, $this->dumper, $this->plugininmoodledir));
         $installers->add(new VendorInstaller($this->moodle, $this->plugin, $this->execute));
 
         if ($this->noInit) {

--- a/src/Installer/InstallerFactory.php
+++ b/src/Installer/InstallerFactory.php
@@ -72,6 +72,10 @@ class InstallerFactory
      * @var bool
      */
     public $noInit;
+    /**
+     * @var bool
+     */
+    public $createDb;
 
     /**
      * @var bool
@@ -85,7 +89,7 @@ class InstallerFactory
      */
     public function addInstallers(InstallerCollection $installers)
     {
-        $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir));
+        $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir, $this->createDb));
         $installers->add(new PluginInstaller($this->moodle, $this->plugin, $this->pluginsDir, $this->dumper, $this->plugininmoodledir));
         $installers->add(new VendorInstaller($this->moodle, $this->plugin, $this->execute));
 

--- a/src/Installer/MoodleInstaller.php
+++ b/src/Installer/MoodleInstaller.php
@@ -63,6 +63,10 @@ class MoodleInstaller extends AbstractInstaller
      * @var bool
      */
     private $createDb;
+    /**
+     * @var bool
+     */
+    private $rewriteConfig;
 
     /**
      * @param Execute          $execute
@@ -73,17 +77,19 @@ class MoodleInstaller extends AbstractInstaller
      * @param string           $branch
      * @param string           $dataDir
      * @param bool             $createDb
+     * @param bool             $rewriteConfig
      */
-    public function __construct(Execute $execute, AbstractDatabase $database, Moodle $moodle, MoodleConfig $config, $repo, $branch, $dataDir, $createDb = true)
+    public function __construct(Execute $execute, AbstractDatabase $database, Moodle $moodle, MoodleConfig $config, $repo, $branch, $dataDir, $createDb = true, $rewriteConfig = true)
     {
-        $this->execute  = $execute;
-        $this->database = $database;
-        $this->moodle   = $moodle;
-        $this->config   = $config;
-        $this->repo     = $repo;
-        $this->branch   = $branch;
-        $this->dataDir  = $dataDir;
-        $this->createDb = $createDb;
+        $this->execute       = $execute;
+        $this->database      = $database;
+        $this->moodle        = $moodle;
+        $this->config        = $config;
+        $this->repo          = $repo;
+        $this->branch        = $branch;
+        $this->dataDir       = $dataDir;
+        $this->createDb      = $createDb;
+        $this->rewriteConfig = $rewriteConfig;
     }
 
     public function install()
@@ -117,9 +123,11 @@ class MoodleInstaller extends AbstractInstaller
             $this->execute->mustRun($this->database->getCreateDatabaseCommand());
         }
 
-        $this->getOutput()->debug('Creating Moodle\'s config file');
-        $contents = $this->config->createContents($this->database, $this->expandPath($this->dataDir));
-        $this->config->dump($this->moodle->directory.'/config.php', $contents);
+        if ($this->rewriteConfig) {
+            $this->getOutput()->debug('Creating Moodle\'s config file');
+            $contents = $this->config->createContents($this->database, $this->expandPath($this->dataDir));
+            $this->config->dump($this->moodle->directory.'/config.php', $contents);
+        }
 
         $this->addEnv('MOODLE_DIR', $this->moodle->directory);
 

--- a/src/Installer/MoodleInstaller.php
+++ b/src/Installer/MoodleInstaller.php
@@ -59,6 +59,10 @@ class MoodleInstaller extends AbstractInstaller
      * @var string
      */
     private $dataDir;
+    /**
+     * @var bool
+     */
+    private $createDb;
 
     /**
      * @param Execute          $execute
@@ -68,8 +72,9 @@ class MoodleInstaller extends AbstractInstaller
      * @param string           $repo
      * @param string           $branch
      * @param string           $dataDir
+     * @param bool             $createDb
      */
-    public function __construct(Execute $execute, AbstractDatabase $database, Moodle $moodle, MoodleConfig $config, $repo, $branch, $dataDir)
+    public function __construct(Execute $execute, AbstractDatabase $database, Moodle $moodle, MoodleConfig $config, $repo, $branch, $dataDir, $createDb = true)
     {
         $this->execute  = $execute;
         $this->database = $database;
@@ -78,6 +83,7 @@ class MoodleInstaller extends AbstractInstaller
         $this->repo     = $repo;
         $this->branch   = $branch;
         $this->dataDir  = $dataDir;
+        $this->createDb = $createDb;
     }
 
     public function install()
@@ -106,8 +112,10 @@ class MoodleInstaller extends AbstractInstaller
         $filesystem->mkdir($dirs);
         $filesystem->chmod($dirs, 0777);
 
-        $this->getOutput()->debug('Create Moodle database');
-        $this->execute->mustRun($this->database->getCreateDatabaseCommand());
+        if ($this->createDb) {
+            $this->getOutput()->debug('Create Moodle database');
+            $this->execute->mustRun($this->database->getCreateDatabaseCommand());
+        }
 
         $this->getOutput()->debug('Creating Moodle\'s config file');
         $contents = $this->config->createContents($this->database, $this->expandPath($this->dataDir));

--- a/src/Installer/MoodleInstaller.php
+++ b/src/Installer/MoodleInstaller.php
@@ -82,11 +82,16 @@ class MoodleInstaller extends AbstractInstaller
 
     public function install()
     {
-        $this->getOutput()->step('Cloning Moodle');
+        if ($this->repo && $this->branch) {
+            $this->getOutput()->step('Cloning Moodle');
 
-        $process = new Process(sprintf('git clone --depth=1 --branch %s %s %s', $this->branch, $this->repo, $this->moodle->directory));
-        $process->setTimeout(null);
-        $this->execute->mustRun($process);
+            $process = new Process(sprintf('git clone --depth=1 --branch %s %s %s', $this->branch, $this->repo,
+                $this->moodle->directory));
+            $process->setTimeout(null);
+            $this->execute->mustRun($process);
+        } else {
+            $this->getOutput()->step('Using local Moodle setup');
+        }
 
         // Expand the path to Moodle so all other installers use absolute path.
         $this->moodle->directory = $this->expandPath($this->moodle->directory);

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -109,6 +109,18 @@ class PluginInstaller extends AbstractInstaller
             $plugins->add(new MoodlePlugin($file->getRealPath()));
         }
 
+        if (file_exists($this->extraPluginsDir.'/plugins.txt')) {
+            $pluginstxt = explode("\n", file_get_contents($this->extraPluginsDir.'/plugins.txt'));
+            foreach ($pluginstxt as $pluginname) {
+                $pluginname = trim($pluginname);
+                if ($pluginname === '') {
+                    continue;
+                }
+                $file = new \SplFileInfo($this->moodle->directory.'/'.$pluginname);
+                $plugins->add(new MoodlePlugin($file->getRealPath()));
+            }
+        }
+
         return $plugins;
     }
 

--- a/src/Installer/PluginInstallerNoCopy.php
+++ b/src/Installer/PluginInstallerNoCopy.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Installer;
+
+use MoodlePluginCI\Bridge\Moodle;
+use MoodlePluginCI\Bridge\MoodlePlugin;
+use MoodlePluginCI\Bridge\MoodlePluginCollection;
+
+/**
+ * Moodle plugins installer.
+ * This will install a plugin without copying it to the Moodle directory. Assuming it's already there.
+ * The list of plugin to install is read from plugin.txt inside the externalplugindir.
+ * All the appropriate plugins will be configured too.
+ */
+class PluginInstallerNoCopy extends AbstractPluginInstaller
+{
+    use TraitInstallerCreateConfig;
+
+    /**
+     * @var Moodle
+     */
+    private $moodle;
+    /**
+     * @var array
+     */
+    private $extraplugins;
+    /**
+     * @var string
+     */
+    private $extraPluginsDir;
+
+    /**
+     * @param Moodle       $moodle
+     * @param ConfigDumper $configDumper
+     * @param string       $extraPluginsDir
+     * @param array        $extraplugins
+     */
+    public function __construct(Moodle $moodle, ConfigDumper $configDumper, $extraPluginsDir = '', $extraplugins = [])
+    {
+        $this->moodle          = $moodle;
+        $this->extraPluginsDir = $extraPluginsDir;
+        $this->configDumper    = $configDumper;
+        $this->extraplugins    = $extraplugins;
+    }
+
+    public function install()
+    {
+        $this->getOutput()->step('Dump configuration');
+
+        $list    = [];
+        $plugins = $this->pluginsToInstall();
+        foreach ($plugins->sortByDependencies()->all() as $plugin) {
+            $directory = $this->moodle->getComponentInstallDirectory($plugin->getComponent());
+            $list[]    = str_replace($this->moodle->directory.'/', '', $directory);
+        }
+        $this->configDumper->addSection('plugins', 'list', $list);
+        $this->createConfigFile($this->moodle->directory.'/.moodle-plugin-ci.yml');
+    }
+
+    /**
+     * @return MoodlePluginCollection
+     */
+    public function pluginsToInstall()
+    {
+        $plugins      = new MoodlePluginCollection();
+        $pluginsNames = $this->extraplugins;
+
+        // Load additional plugins from the plugins.txt file.
+        if (file_exists($this->extraPluginsDir.'/plugins.txt')) {
+            $pluginsTxt = explode("\n", file_get_contents($this->extraPluginsDir.'/plugins.txt'));
+            foreach ($pluginsTxt as $pluginName) {
+                $pluginName = trim($pluginName);
+                if ($pluginName === '') {
+                    continue;
+                }
+                $pluginsNames[] = $pluginName;
+            }
+        }
+
+        $pluginsNames = array_unique($pluginsNames);
+        // Add plugins to the collections.
+        foreach ($pluginsNames as $pluginName) {
+            $file = new \SplFileInfo($this->moodle->directory.'/'.$pluginName);
+            if (!$file->isDir()) {
+                throw new \RuntimeException(sprintf('Plugin %s is not installed in standard Moodle', $pluginName));
+            }
+            $plugins->add(new MoodlePlugin($file->getRealPath()));
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * We prepapre all the plugin to be tested.
+     *
+     * @return MoodlePlugin[]
+     */
+    public function pluginsToPrepare()
+    {
+        return $this->pluginsToInstall()->all();
+    }
+
+    public function stepCount()
+    {
+        return 2;
+    }
+}

--- a/src/Installer/TraitInstallerCreateConfig.php
+++ b/src/Installer/TraitInstallerCreateConfig.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Installer;
+
+/**
+ * Abstract Installer create config.
+ */
+trait TraitInstallerCreateConfig
+{
+    /**
+     * @var ConfigDumper
+     */
+    protected $configDumper = null;
+
+    /**
+     * Create plugin config file.
+     *
+     * @param string $toFile
+     */
+    public function createConfigFile($toFile)
+    {
+        if ($this->configDumper === null) {
+            $this->configDumper = new ConfigDumper();
+        }
+        if (file_exists($toFile)) {
+            $this->getOutput()->debug('Config file already exists in plugin, skipping creation of config file.');
+
+            return;
+        }
+        if (!$this->configDumper->hasConfig()) {
+            $this->getOutput()->debug('No config to write out, skipping creation of config file.');
+
+            return;
+        }
+        $this->configDumper->dump($toFile);
+        $this->getOutput()->debug('Created config file at '.$toFile);
+    }
+}

--- a/src/Installer/VendorInstaller.php
+++ b/src/Installer/VendorInstaller.php
@@ -52,7 +52,8 @@ class VendorInstaller extends AbstractInstaller
         if ($this->plugin->hasUnitTests() || $this->plugin->hasBehatFeatures()) {
             $processes[] = new Process('composer install --no-interaction --prefer-dist', $this->moodle->directory, null, null, null);
         }
-        $processes[] = new Process('npm install -g --no-progress grunt', null, null, null, null);
+        $sudo        = getenv('NPM_SUDO') ? 'sudo ' : '';
+        $processes[] = new Process($sudo.'npm install -g --no-progress grunt', null, null, null, null);
 
         $this->execute->mustRunAll($processes);
 

--- a/src/Installer/VendorInstaller.php
+++ b/src/Installer/VendorInstaller.php
@@ -56,6 +56,11 @@ class VendorInstaller extends AbstractInstaller
         $this->getOutput()->step('Install global dependencies');
 
         $processes = [];
+
+        if (empty($this->plugins)) {
+            $this->getOutput()->warning('There is no plugin to prepare');
+        }
+
         if ($this->shouldInstallComposer()) {
             $this->getOutput()->info(sprintf('Install composer packages on the Moodle directory: %s', $this->moodle->directory));
             $processes[] = new Process('composer install --no-interaction --prefer-dist', $this->moodle->directory, null, null, null);

--- a/src/Installer/VendorInstaller.php
+++ b/src/Installer/VendorInstaller.php
@@ -57,6 +57,7 @@ class VendorInstaller extends AbstractInstaller
 
         $processes = [];
         if ($this->shouldInstallComposer()) {
+            $this->getOutput()->info(sprintf('Install composer packages on the Moodle directory: %s', $this->moodle->directory));
             $processes[] = new Process('composer install --no-interaction --prefer-dist', $this->moodle->directory, null, null, null);
         }
         $sudo        = getenv('NPM_SUDO') ? 'sudo ' : '';

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -103,6 +103,27 @@ class InstallCommandTest extends MoodleTestCase
         $this->assertInstanceOf(PluginInstallerNoCopy::class, $collection->all()[1]);
     }
 
+    public function testNoConfigRewriteFlag()
+    {
+        $command          = new InstallCommand($this->tempDir.'/.env');
+        $command->install = new DummyInstall(new InstallOutput());
+
+        $application = new Application();
+        $application->add($command);
+
+        $input            = new ArrayInput(
+            [
+                '--db-create-skip'    => true,
+                '--db-type'           => 'mysqli',
+                '--no-clone'          => true,
+                '--no-config-rewrite' => true,
+            ], $command->getDefinition()
+        );
+        $command->execute = new DummyExecute();
+        $factory          = $command->initializeInstallerFactory($input);
+        $this->assertTrue($factory->noConfigRewrite);
+    }
+
     /**
      * @param string $value
      * @param array  $expected

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -50,6 +50,32 @@ class InstallCommandTest extends MoodleTestCase
         $this->assertSame(0, $commandTester->getStatusCode());
     }
 
+    public function testMoodleDirEnv()
+    {
+        $previous = getenv('MOODLE_DIR');
+        try {
+            $fakeMoodleDir = $this->tempDir.'/moodle_fake';
+            putenv('MOODLE_DIR='.$fakeMoodleDir);
+
+            $command          = new InstallCommand($this->tempDir.'/.env');
+            $command->install = new DummyInstall(new InstallOutput());
+
+            $application = new Application();
+            $application->add($command);
+
+            $input   = new ArrayInput(
+                [
+                    '--no-clone' => true,
+                    '--db-type'  => 'mysqli',
+                ], $command->getDefinition()
+            );
+            $factory = $command->initializeInstallerFactory($input);
+            $this->assertSame($fakeMoodleDir, $factory->moodle->directory);
+        } finally {
+            putenv('MOODLE_DIR='.$previous);
+        }
+    }
+
     /**
      * @param string $value
      * @param array  $expected

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -76,6 +76,25 @@ class InstallCommandTest extends MoodleTestCase
         }
     }
 
+    public function testDbCreateSkipFlag()
+    {
+        $command          = new InstallCommand($this->tempDir.'/.env');
+        $command->install = new DummyInstall(new InstallOutput());
+
+        $application = new Application();
+        $application->add($command);
+
+        $input   = new ArrayInput(
+            [
+                '--db-create-skip' => true,
+                '--db-type'        => 'mysqli',
+                '--no-clone'       => true,
+            ], $command->getDefinition()
+        );
+        $factory = $command->initializeInstallerFactory($input);
+        $this->assertFalse($factory->createDb);
+    }
+
     /**
      * @param string $value
      * @param array  $expected

--- a/tests/Fake/Bridge/DummyMoodle.php
+++ b/tests/Fake/Bridge/DummyMoodle.php
@@ -28,12 +28,14 @@ class DummyMoodle extends Moodle
 
     public function normalizeComponent($component)
     {
-        return ['local', 'travis'];
+        // It will not work with all the plugin types.
+        return explode('_', $component);
     }
 
     public function getComponentInstallDirectory($component)
     {
-        return $this->directory.'/local/travis';
+        // This doesn't simulate Moodle's \core_component::fetch_plugintypes nicely.
+        return $this->directory.'/'.str_replace('_', '/', $component);
     }
 
     public function getBranch()

--- a/tests/Fake/Process/DummyExecute.php
+++ b/tests/Fake/Process/DummyExecute.php
@@ -17,30 +17,44 @@ use Symfony\Component\Process\Process;
 
 class DummyExecute extends Execute
 {
+    /**
+     * @var string[] histroy of the command to run
+     */
+    public $history = [];
+
     /** @noinspection PhpMissingParentConstructorInspection */
     public function __construct()
     {
         // Do nothing.
     }
 
+    protected function addToHistory($cmd)
+    {
+        $this->history[] = $cmd instanceof Process ? $cmd->getCommandLine() : $cmd;
+    }
+
     public function run($cmd, $error = null)
     {
+        $this->addToHistory($cmd);
+
         return new DummyProcess('dummy');
     }
 
     public function mustRun($cmd, $error = null)
     {
-        return new DummyProcess('dummy');
+        return $this->run($cmd, $error);
     }
 
     public function runAll($processes)
     {
-        // Do nothing.
+        $this->mustRunAll($processes);
     }
 
     public function mustRunAll($processes)
     {
-        // Do nothing.
+        foreach ($processes as $process) {
+            $this->addToHistory($process);
+        }
     }
 
     public function passThrough($commandline, $cwd = null, $timeout = null)
@@ -55,5 +69,13 @@ class DummyExecute extends Execute
         }
 
         return new DummyProcess($process->getCommandLine(), $process->getWorkingDirectory(), null, null, $process->getTimeout());
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHistory()
+    {
+        return $this->history;
     }
 }

--- a/tests/Fixture/moodle-local_emptyplugin/README.md
+++ b/tests/Fixture/moodle-local_emptyplugin/README.md
@@ -1,0 +1,1 @@
+This is an empty plugin, it is used for Unit Testing.

--- a/tests/Fixture/moodle-local_emptyplugin/version.php
+++ b/tests/Fixture/moodle-local_emptyplugin/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version info
+ *
+ * @package   local_emptyplugin
+ * @copyright Copyright (c) 2015 Blackboard Inc. (http://www.blackboard.com)
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/** @var object $plugin */
+$plugin->version      = 2015071000;
+$plugin->requires     = 2014051200;  // Moodle 2.7.
+$plugin->component    = 'local_emptyplugin';
+$plugin->dependencies = ['mod_forum' => ANY_VERSION];
+$plugin->maturity     = MATURITY_STABLE;

--- a/tests/Installer/PluginInstallerTest.php
+++ b/tests/Installer/PluginInstallerTest.php
@@ -16,6 +16,7 @@ use MoodlePluginCI\Bridge\MoodlePlugin;
 use MoodlePluginCI\Bridge\MoodlePluginCollection;
 use MoodlePluginCI\Installer\ConfigDumper;
 use MoodlePluginCI\Installer\PluginInstaller;
+use MoodlePluginCI\Installer\PluginInstallerNoCopy;
 use MoodlePluginCI\Tests\Fake\Bridge\DummyMoodle;
 use MoodlePluginCI\Tests\FilesystemTestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -27,8 +28,9 @@ class PluginInstallerTest extends FilesystemTestCase
     public function testInstall()
     {
         $fixture   = __DIR__.'/../Fixture/moodle-local_travis';
-        $plugin    = new MoodlePlugin($fixture);
-        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin, '', new ConfigDumper());
+        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $fixture, '', new ConfigDumper());
+        $plugin    = $installer->getLocalPluginSingleton();
+
         $installer->install();
 
         $this->assertSame($installer->stepCount(), $installer->getOutput()->getStepCount());
@@ -43,7 +45,7 @@ class PluginInstallerTest extends FilesystemTestCase
     {
         $fixture    = realpath(__DIR__.'/../Fixture/moodle-local_travis');
         $plugin     = new MoodlePlugin($fixture);
-        $installer  = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin, '', new ConfigDumper());
+        $installer  = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin->directory, '', new ConfigDumper());
         $installDir = $installer->installPluginIntoMoodle($plugin);
 
         $this->assertTrue(is_dir($installDir));
@@ -62,31 +64,34 @@ class PluginInstallerTest extends FilesystemTestCase
 
     public function testInstallPluginIntoMoodleWithNoClone()
     {
-        $fixture = realpath(__DIR__.'/../Fixture/moodle-local_travis');
-        $plugin  = new MoodlePlugin($fixture);
+        $pluginsnames = [
+            'moodle-local_travis'      => 'local/travis',
+            'moodle-local_emptyplugin' => 'local/emptyplugin',
+        ];
 
-        // Copy the plugin in the Moodle directory as expected.
-        $moodle     = new DummyMoodle($this->tempDir);
-        $directory  = $moodle->getComponentInstallDirectory($plugin->getComponent());
-        $filesystem = new Filesystem();
-        $filesystem->mirror($plugin->directory, $directory);
+        $toinstallplugins = [];
+        $moodle           = new DummyMoodle($this->tempDir);
+        foreach ($pluginsnames as $component => $location) {
+            // Copy the plugin in the Moodle directory as expected.
+            $fixture           = realpath(__DIR__.'/../Fixture/'.$component);
+            $directoryInMoodle = $this->tempDir.'/'.$location;
+            $filesystem        = new Filesystem();
+            $filesystem->mirror($fixture, $directoryInMoodle);
+            $toinstallplugins[] = new MoodlePlugin($directoryInMoodle);
+        }
         try {
-            $installer  = new PluginInstaller($moodle, $plugin, '', new ConfigDumper(), true);
-            $installDir = $installer->installPluginIntoMoodle($plugin);
-            $this->assertTrue(is_dir($installDir));
-
-            $finder = new Finder();
-            $finder->files()->in($fixture);
-
-            /* @var \SplFileInfo $file */
-            foreach ($finder as $file) {
-                $path = str_replace($fixture, $this->tempDir.'/local/travis', $file->getPathname());
-
-                $this->assertFileExists($path);
-                $this->assertFileEquals($file->getPathname(), $path);
+            $installer = new PluginInstallerNoCopy($moodle, new ConfigDumper(), '', array_values($pluginsnames));
+            $installer->install();
+            foreach ($toinstallplugins as $plugin) {
+                $this->assertFileExists($plugin->directory);
             }
+
+            $config = Yaml::parseFile($this->tempDir.'/.moodle-plugin-ci.yml');
+            $this->assertSame(['plugins' => ['list' => array_values($pluginsnames)]], $config, 'The dumped config is wrong');
         } finally {
-            $filesystem->remove($directory);
+            foreach ($toinstallplugins as $plugin) {
+                $filesystem->remove($plugin->directory);
+            }
         }
     }
 
@@ -98,7 +103,7 @@ class PluginInstallerTest extends FilesystemTestCase
 
         $fixture   = realpath(__DIR__.'/../Fixture/moodle-local_travis');
         $plugin    = new MoodlePlugin($fixture);
-        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin, '', new ConfigDumper());
+        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin->directory, '', new ConfigDumper());
         $installer->installPluginIntoMoodle($plugin);
     }
 
@@ -107,42 +112,78 @@ class PluginInstallerTest extends FilesystemTestCase
         $this->expectException(\RuntimeException::class);
 
         $this->fs->remove($this->tempDir.'/local/travis');
-        $fixture   = realpath(__DIR__.'/../Fixture/moodle-local_travis');
-        $plugin    = new MoodlePlugin($fixture);
-        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin, '', new ConfigDumper(), true);
-        $installer->installPluginIntoMoodle($plugin);
+        $installer = new PluginInstallerNoCopy(new DummyMoodle($this->tempDir), new ConfigDumper(), '', ['local/travis']);
+        $installer->install();
     }
 
     public function testCreateIgnoreFile()
     {
         $filename = $this->tempDir.'/.moodle-plugin-ci.yml';
-        $expected = ['filter' => [
-            'notPaths' => ['foo/bar', 'very/bad.php'],
-            'notNames' => ['*-m.js', 'bad.php'],
-        ]];
+        $expected = [
+            'filter' => [
+                'notPaths' => ['foo/bar', 'very/bad.php'],
+                'notNames' => ['*-m.js', 'bad.php'],
+            ],
+        ];
 
         $dumper = new ConfigDumper();
         $dumper->addSection('filter', 'notPaths', ['foo/bar', 'very/bad.php']);
         $dumper->addSection('filter', 'notNames', ['*-m.js', 'bad.php']);
 
-        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), new MoodlePlugin($this->tempDir), '', $dumper);
+        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $this->tempDir, '', $dumper);
         $installer->createConfigFile($filename);
 
         $this->assertFileExists($filename);
         $this->assertSame($expected, Yaml::parse(file_get_contents($filename)));
     }
 
-    public function testScanForPlugins()
+    public function testPluginsToInstall()
     {
         $fixture = __DIR__.'/../Fixture/moodle-local_travis';
-
         $this->fs->mirror($fixture, $this->tempDir.'/moodle-local_travis');
 
-        $plugin    = new MoodlePlugin($fixture);
-        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $plugin, $this->tempDir, new ConfigDumper());
+        $extraplugins = $this->tempDir.'/extraplugins';
+        $this->fs->mkdir($extraplugins);
 
-        $plugins = $installer->scanForPlugins();
+        $fixture = __DIR__.'/../Fixture/moodle-local_emptyplugin';
+        $this->fs->mirror($fixture, $extraplugins.'/moodle-emptyplugin');
+
+        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $fixture, $extraplugins, new ConfigDumper());
+
+        $plugins = $installer->pluginsToInstall();
         $this->assertInstanceOf(MoodlePluginCollection::class, $plugins);
-        $this->assertCount(1, $plugins);
+        $this->assertCount(2, $plugins);
+    }
+
+    public function testPluginsToInstallNoCopy()
+    {
+        $extraPluginDirectory = $this->tempDir.'/plugins';
+        $this->fs->mkdir($extraPluginDirectory);
+        file_put_contents($extraPluginDirectory.'/plugins.txt', implode("\n", ['local/travis']));
+        try {
+            $fixture = __DIR__.'/../Fixture/moodle-local_travis';
+            $this->fs->mirror($fixture, $this->tempDir.'/local/travis');
+
+            $installer = new PluginInstallerNoCopy(new DummyMoodle($this->tempDir), new ConfigDumper(), $extraPluginDirectory);
+
+            $plugins = $installer->pluginsToInstall();
+            $this->assertInstanceOf(MoodlePluginCollection::class, $plugins);
+            $this->assertCount(1, $plugins);
+        } finally {
+            $this->fs->remove($extraPluginDirectory.'/plugins.txt');
+        }
+    }
+
+    public function testLocalPluginSingleton()
+    {
+        $plugindir = $this->tempDir.'/fakeplugin';
+        $this->fs->mkdir($plugindir);
+
+        $installer = new PluginInstaller(new DummyMoodle($this->tempDir), $plugindir, null, new ConfigDumper());
+        $this->assertInstanceOf(MoodlePlugin::class, $installer->getLocalPluginSingleton());
+        $this->assertSame($plugindir, $installer->getLocalPluginSingleton()->directory);
+        $installer->getLocalPluginSingleton()->directory = 123;
+        $this->assertSame(123, $installer->getLocalPluginSingleton()->directory);
+        $this->fs->remove($plugindir);
     }
 }

--- a/tests/Installer/TestSuiteInstallerTest.php
+++ b/tests/Installer/TestSuiteInstallerTest.php
@@ -33,7 +33,7 @@ class TestSuiteInstallerTest extends MoodleTestCase
     {
         $installer = new TestSuiteInstaller(
             new DummyMoodle(''),
-            new MoodlePlugin($this->pluginDir),
+            [new MoodlePlugin($this->pluginDir)],
             new DummyExecute()
         );
         $installer->install();
@@ -45,7 +45,7 @@ class TestSuiteInstallerTest extends MoodleTestCase
     {
         $installer = new TestSuiteInstaller(
             new DummyMoodle(''),
-            new MoodlePlugin($this->pluginDir),
+            [new MoodlePlugin($this->pluginDir)],
             new DummyExecute()
         );
 
@@ -62,7 +62,7 @@ class TestSuiteInstallerTest extends MoodleTestCase
     {
         $installer = new TestSuiteInstaller(
             new DummyMoodle(''),
-            new MoodlePlugin($this->pluginDir),
+            [new MoodlePlugin($this->pluginDir)],
             new DummyExecute()
         );
 
@@ -80,7 +80,7 @@ class TestSuiteInstallerTest extends MoodleTestCase
         $xmlFile   = $this->pluginDir.'/phpunit.xml';
         $installer = new TestSuiteInstaller(
             new DummyMoodle(''),
-            new MoodlePlugin($this->pluginDir),
+            [new MoodlePlugin($this->pluginDir)],
             new DummyExecute()
         );
 

--- a/tests/Installer/VendorInstallerTest.php
+++ b/tests/Installer/VendorInstallerTest.php
@@ -49,4 +49,36 @@ class VendorInstallerTest extends \PHPUnit_Framework_TestCase
             putenv('NPM_SUDO='.$env);
         }
     }
+
+    public function testComposerInstall()
+    {
+        $dummy  = new DummyExecute();
+        $plugin = new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_travis');
+        $this->assertTrue($plugin->hasUnitTests());
+        $this->assertTrue($plugin->hasBehatFeatures());
+        $installer = new VendorInstaller(
+            new DummyMoodle(''),
+            [$plugin],
+            $dummy
+        );
+        $installer->install();
+        $commands = $dummy->getHistory();
+        $this->assertSame('composer install --no-interaction --prefer-dist', $commands[0]);
+    }
+
+    public function testNoComposerInstall()
+    {
+        $plugin = new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_emptyplugin');
+        $this->assertFalse($plugin->hasUnitTests());
+        $this->assertFalse($plugin->hasBehatFeatures());
+        $dummy     = new DummyExecute();
+        $installer = new VendorInstaller(
+            new DummyMoodle(''),
+            [$plugin],
+            $dummy
+        );
+        $installer->install();
+        $commands = $dummy->getHistory();
+        $this->assertNotTrue('composer install --no-interaction --prefer-dist' === $commands[0]);
+    }
 }

--- a/tests/Installer/VendorInstallerTest.php
+++ b/tests/Installer/VendorInstallerTest.php
@@ -30,4 +30,23 @@ class VendorInstallerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($installer->stepCount(), $installer->getOutput()->getStepCount());
     }
+
+    public function testInstallSudo()
+    {
+        $env = getenv('NPM_SUDO');
+        try {
+            putenv('NPM_SUDO=1');
+            $dummy     = new DummyExecute();
+            $installer = new VendorInstaller(
+                new DummyMoodle(''),
+                new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_travis'),
+                $dummy
+            );
+            $installer->install();
+            $commands = $dummy->getHistory();
+            $this->assertSame('sudo npm install -g --no-progress grunt', $commands[1]);
+        } finally {
+            putenv('NPM_SUDO='.$env);
+        }
+    }
 }

--- a/tests/Installer/VendorInstallerTest.php
+++ b/tests/Installer/VendorInstallerTest.php
@@ -23,7 +23,7 @@ class VendorInstallerTest extends \PHPUnit_Framework_TestCase
     {
         $installer = new VendorInstaller(
             new DummyMoodle(''),
-            new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_travis'),
+            [new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_travis')],
             new DummyExecute()
         );
         $installer->install();
@@ -39,7 +39,7 @@ class VendorInstallerTest extends \PHPUnit_Framework_TestCase
             $dummy     = new DummyExecute();
             $installer = new VendorInstaller(
                 new DummyMoodle(''),
-                new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_travis'),
+                [new MoodlePlugin(__DIR__.'/../Fixture/moodle-local_travis')],
                 $dummy
             );
             $installer->install();

--- a/tests/MoodleTestCase.php
+++ b/tests/MoodleTestCase.php
@@ -23,15 +23,24 @@ class MoodleTestCase extends FilesystemTestCase
      * @var string
      */
     protected $pluginDir;
+    /**
+     * @var string
+     */
+    protected $extrapluginDir;
 
+    /**
+     * Setup.
+     */
     protected function setUp()
     {
         parent::setUp();
 
-        $this->moodleDir = $this->tempDir;
-        $this->pluginDir = $this->tempDir.'/local/travis';
+        $this->moodleDir      = $this->tempDir.'/moodle';
+        $this->pluginDir      = $this->tempDir.'/local/travis';
+        $this->extrapluginDir = $this->tempDir.'/extraplugin';
 
         $this->fs->mirror(__DIR__.'/Fixture/moodle', $this->moodleDir);
         $this->fs->mirror(__DIR__.'/Fixture/moodle-local_travis', $this->pluginDir);
+        $this->fs->mirror(__DIR__.'/Fixture/moodle-local_emptyplugin', $this->extrapluginDir.'/local/emptyplugin');
     }
 }


### PR DESCRIPTION
Hello,
This PR add the ability to use this plugin inside a full Moodle repository and test multiple plugins already present in the repository (provided as submodules for example).

It means that the installation command will not clone the Moodle repository but use an existing local folder instead. And that the plugins are not "copied" inside Moodle directory as they are already there.
Installation has a new option called `no-clone`.

> /tmp/bin/moodle-plugin-ci --no-clone --moodle /var/www/moodle --db-type=$DB_TYPE

The user must then specify the command to run and the full plugin directory:

> /tmp/bin/moodle-plugin-ci ${command} /var/www/moodle/${plugin}

I also added an environment variable check called `NPM_SUDO` that add a _sudo_ to run the command `npm install -g --no-progress grunt`. This was needed as a global installation may require sudo privileges (locally or on Gitlab-Ci for example).

Note that I refactored a lot, mainly to allow `VendorInstaller` and `TestSuiteInstaller` to be executed on more than one plugin.

It's the first time that I contribute on the project. Any suggestion are welcomed.

Thanks,