### PR TITLE
Clean up submodules

### DIFF
--- a/src/Installer/MoodleInstaller.php
+++ b/src/Installer/MoodleInstaller.php
@@ -91,6 +91,14 @@ class MoodleInstaller extends AbstractInstaller
         // Expand the path to Moodle so all other installers use absolute path.
         $this->moodle->directory = $this->expandPath($this->moodle->directory);
 
+        // If there are submodules, we clean up empty directories, since we
+        // don't initialise them properly anyway.
+        if (is_file($this->moodle->directory.'/.gitmodules')) {
+            $process = new Process(sprintf('git config -f %s --get-regexp \'^submodule\..*\.path$\' | awk \'{ print $2 }\' | xargs -i rmdir "%s/{}"', $this->moodle->directory.'/.gitmodules', $this->moodle->directory));
+            $process->setTimeout(null);
+            $this->execute->mustRun($process);
+        }
+
         $this->getOutput()->step('Moodle assets');
 
         $this->getOutput()->debug('Creating Moodle data directories');


### PR DESCRIPTION
This is only applicable if MOODLE_REPO env var is defined and custom repo contains submodules. We do not have the means of intialising submodules, so the patch is removing empty dirs, so that the Moodle installation will not fail. If plugin depends on another one, you can add dependency using `moodle-plugin-ci add-plugin` statement in `.travis.yml` instead (see [Adding extra plugins](https://github.com/blackboard-open-source/moodle-plugin-ci/blob/master/docs/AddExtraPlugins.md) manual for more details).