### PR TITLE
Update moodle-local_codechecker to 2.9.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_codechecker",
-        "version": "2.9.3",
+        "version": "2.9.4",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
           "type": "git",
-          "reference": "v2.9.3"
+          "reference": "v2.9.4"
         },
         "autoload": {
           "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2a2dd2ad794c39dd0cd4417999c5025",
+    "content-hash": "30bdf942f332361de8df709363a405fb",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -254,11 +254,11 @@
         },
         {
             "name": "moodlehq/moodle-local_codechecker",
-            "version": "2.9.3",
+            "version": "2.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-                "reference": "v2.9.3"
+                "reference": "v2.9.4"
             },
             "type": "library",
             "autoload": {
@@ -382,7 +382,7 @@
                     "homepage": "http://blog.astrumfutura.com"
                 },
                 {
-                    "name": "Théo FIDRY",
+                    "name": "Théo Fidry",
                     "email": "theo.fidry@gmail.com"
                 }
             ],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
   [#91](https://github.com/blackboard-open-source/moodle-plugin-ci/issues/91).
 - Updated verion of `moodlehq/moodle-local_ci` to fix Mustache linting. See
   [#91](https://github.com/blackboard-open-source/moodle-plugin-ci/issues/91).
+- Updated version of `moodlehq/moodle-local_codechecker`.
 
 ### Added
 - New help document: [CLI commands and options](CLI.md)


### PR DESCRIPTION
A trivial patch to include recent changes in the `local_codechecker` (mainly in sniffs).