### PR TITLE
Add optional env variables for Behat wwwroot and wdhost

### DIFF
--- a/res/template/config.php.txt
+++ b/res/template/config.php.txt
@@ -39,11 +39,11 @@ $CFG->behat_faildump_path = '{{BEHATDUMP}}';
 $CFG->behat_profiles      = [
     'default' => [
         'browser' => 'firefox',
-        'wd_host' => 'http://localhost:4444/wd/hub',
+        'wd_host' => '{{BEHATWDHOST}}',
     ],
     'chrome' => [
         'browser' => 'chrome',
-        'wd_host' => 'http://localhost:4444/wd/hub',
+        'wd_host' => '{{BEHATWDHOST}}',
     ],
 ];
 

--- a/src/Bridge/MoodleConfig.php
+++ b/src/Bridge/MoodleConfig.php
@@ -45,7 +45,8 @@ class MoodleConfig
             '{{PHPUNITDATAROOT}}' => $dataDir.'/phpu_moodledata',
             '{{BEHATDATAROOT}}'   => $dataDir.'/behat_moodledata',
             '{{BEHATDUMP}}'       => $dataDir.'/behat_dump',
-            '{{BEHATWWWROOT}}'    => 'http://localhost:8000',
+            '{{BEHATWWWROOT}}'    => getenv('MOODLE_BEHAT_WWWROOT') ?: 'http://localhost:8000',
+            '{{BEHATWDHOST}}'     => getenv('MOODLE_BEHAT_WDHOST') ?: 'http://localhost:4444/wd/hub',
             '{{EXTRACONFIG}}'     => self::PLACEHOLDER,
         ];
 


### PR DESCRIPTION
When user disables Behat services explicitly by setting  `MOODLE_START_BEHAT_SERVERS = 'NO'` in the environment (e.g. [custom setup of Selenium](https://docs.travis-ci.com/user/chrome#behat) is used), there should be a way to provide alternatives for `behat_wwwroot` config value and Senenium wd_host. This patch is addressing this requirement.