### PR TITLE
Add max-warnings to codechecker and grunt eslint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_codechecker",
-        "version": "2.9.3",
+        "version": "2.9.5",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
           "type": "git",
-          "reference": "v2.9.3"
+          "reference": "v2.9.5"
         },
         "autoload": {
           "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2a2dd2ad794c39dd0cd4417999c5025",
+    "content-hash": "5daa174ad53783108f138609623f9e54",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -254,11 +254,11 @@
         },
         {
             "name": "moodlehq/moodle-local_codechecker",
-            "version": "2.9.3",
+            "version": "2.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-                "reference": "v2.9.3"
+                "reference": "v2.9.5"
             },
             "type": "library",
             "autoload": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
   7.2 and 7.3 (per release notes).
 - Replaced Selenium in-built functionality with docker image for Selenium
   Standalone server. See [#99](https://github.com/blackboard-open-source/moodle-plugin-ci/issues/99).
+- Updated version of `moodlehq/moodle-local_codechecker`.
 
 ### Added
 - New help document: [CLI commands and options](CLI.md)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -380,7 +380,7 @@ Run Moodle Code Checker on a plugin
 
 ### Usage
 
-* `codechecker [-s|--standard STANDARD] [--] <plugin>`
+* `codechecker [-s|--standard STANDARD] [--max-warnings MAX-WARNINGS] [--] <plugin>`
 
 Run Moodle Code Checker on a plugin
 
@@ -404,6 +404,15 @@ The name or path of the coding standard to use
 * Is value required: yes
 * Is multiple: no
 * Default: `'moodle'`
+
+#### `--max-warnings`
+
+Number of warnings to trigger nonzero exit code - default: -1
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Default: `-1`
 
 #### `--help|-h`
 
@@ -570,7 +579,7 @@ Run Grunt task on a plugin
 
 ### Usage
 
-* `grunt [-m|--moodle MOODLE] [-t|--tasks TASKS] [--] <plugin>`
+* `grunt [-m|--moodle MOODLE] [-t|--tasks TASKS] [--show-lint-warnings] [--max-lint-warnings MAX-LINT-WARNINGS] [--] <plugin>`
 
 Run Grunt task on a plugin
 
@@ -603,6 +612,24 @@ The Grunt tasks to run
 * Is value required: yes
 * Is multiple: yes
 * Default: `array (  0 => 'amd',  1 => 'yui',  2 => 'gherkinlint',  3 => 'stylelint:css',  4 => 'stylelint:less',  5 => 'stylelint:scss',)`
+
+#### `--show-lint-warnings`
+
+Show eslint warnings
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--max-lint-warnings`
+
+Maximum number of eslint warnings
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Default: `''`
 
 #### `--help|-h`
 

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -101,6 +101,7 @@ script:
 # This step runs the Moodle Code Checker to make sure that your plugin
 # conforms to the Moodle coding standards.  It is highly recommended
 # that you keep this step.
+# To fail on warnings use --max-warnings 0
   - moodle-plugin-ci codechecker
 # This step runs Moodle PHPDoc checker on your plugin.
   - moodle-plugin-ci phpdoc
@@ -115,6 +116,7 @@ script:
 # tasks relevant to your plugin and Moodle version, but you can run
 # specific tasks by passing them as options,
 # EG: moodle-plugin-ci grunt -t task1 -t task2
+# To fail on eslint warnings use --max-lint-warnings 0
   - moodle-plugin-ci grunt
 # This step runs the PHPUnit tests of your plugin.  If your plugin has
 # PHPUnit tests, then it is highly recommended that you keep this step.

--- a/src/Command/CodeCheckerCommand.php
+++ b/src/Command/CodeCheckerCommand.php
@@ -44,7 +44,9 @@ class CodeCheckerCommand extends AbstractPluginCommand
 
         $this->setName('codechecker')
             ->setDescription('Run Moodle Code Checker on a plugin')
-            ->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The name or path of the coding standard to use', 'moodle');
+            ->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The name or path of the coding standard to use', 'moodle')
+            ->addOption('max-warnings', null, InputOption::VALUE_REQUIRED,
+                'Number of warnings to trigger nonzero exit code - default: -1', -1);
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -86,6 +88,8 @@ class CodeCheckerCommand extends AbstractPluginCommand
         $sniffer->process($files, $this->standard);
         $results = $sniffer->reporting->printReport('full', false, $sniffer->cli->getCommandLineValues(), null, 120);
 
-        return $results['errors'] > 0 ? 1 : 0;
+        $maxwarnings = (int) $input->getOption('max-warnings');
+
+        return ($results['errors'] > 0 || ($maxwarnings >= 0 && $results['warnings'] > $maxwarnings)) ? 1 : 0;
     }
 }

--- a/src/Command/CodeFixerCommand.php
+++ b/src/Command/CodeFixerCommand.php
@@ -14,6 +14,7 @@ namespace MoodlePluginCI\Command;
 
 use MoodlePluginCI\Bridge\CodeSnifferCLI;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -23,10 +24,11 @@ class CodeFixerCommand extends CodeCheckerCommand
 {
     protected function configure()
     {
-        parent::configure();
+        AbstractPluginCommand::configure();
 
         $this->setName('phpcbf')
-            ->setDescription('Run Code Beautifier and Fixer on a plugin');
+            ->setDescription('Run Code Beautifier and Fixer on a plugin')
+            ->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The name or path of the coding standard to use', 'moodle');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/GruntCommand.php
+++ b/src/Command/GruntCommand.php
@@ -40,7 +40,10 @@ class GruntCommand extends AbstractMoodleCommand
 
         $this->setName('grunt')
             ->setDescription('Run Grunt task on a plugin')
-            ->addOption('tasks', 't', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The Grunt tasks to run', $tasks);
+            ->addOption('tasks', 't', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The Grunt tasks to run', $tasks)
+            ->addOption('show-lint-warnings', null, InputOption::VALUE_NONE, 'Show eslint warnings')
+            ->addOption('max-lint-warnings', null, InputOption::VALUE_REQUIRED,
+            'Maximum number of eslint warnings', '');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -66,7 +69,14 @@ class GruntCommand extends AbstractMoodleCommand
             }
 
             $builder = ProcessBuilder::create()
-                ->setPrefix('grunt')
+                ->setPrefix('grunt');
+            if ($input->getOption('show-lint-warnings')) {
+                $builder->add('--show-lint-warnings');
+            }
+            if (strlen($input->getOption('max-lint-warnings'))) {
+                $builder->add('--max-lint-warnings='.((int) $input->getOption('max-lint-warnings')));
+            }
+            $builder
                 ->add($task->taskName)
                 ->setWorkingDirectory($task->workingDirectory)
                 ->setTimeout(null);


### PR DESCRIPTION
I want to be more strict with the checks and fail on both code and eslint warnings. Therefore I propose the max-warning options.

1. Add option `moodle-plugin-ci codechecker --max-warnings 0`, this means that codechecker will return non-zero status if there are any warnings, even when there are no errors.

2. Add option `moodle-plugin-ci grunt --max-lint-warnings 0`, this is the same setting as you can pass to `grunt` itself added in https://tracker.moodle.org/browse/MDL-68323 . It is already integrated and will be available in 3.7.6, 3.8.3 and above. This will tell grunt to fail if there are any eslint warnings.

3. Add option `moodle-plugin-ci grunt --show-lint-warnings`, again, the same setting as you can pass to `grunt` in moodle, this already existed in moodle. It shows eslint warnings but does not fail if there are warnings, only fails on errors.

This PR should replace https://github.com/blackboard-open-source/moodle-plugin-ci/pull/89 because the approach there was incorrect (and I can't do anything to that PR because I did not create it)

Additionally this PR contains a local_codechecker version bump to 2.9.5, this can replace https://github.com/blackboard-open-source/moodle-plugin-ci/pull/105 