### PR TITLE
Provide optional argument for 'install' to initialize test suites only.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,9 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ### Added
 - `moodle-plugin-ci install` now provides an option `--no-init` to skip initialization of the Behat and PHPUnit
   test suites.  Only use this option if execution of these tests are not required.
+- `moodle-plugin-ci install` now provides an option `--init-only` to run initialization of the Behat and PHPUnit
+  test suites only. Can be used if `moodle-plugin-ci install` is called with `--no-init` before. ED: call
+  `moodle-plugin-ci install --no-init`, apply a patch, call `moodle-plugin-ci install --init-only`.
 
 ## [2.1.1] - 2017-09-29
 ### Fixed

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -91,7 +91,8 @@ class InstallCommand extends Command
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
-            ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization');
+            ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization')
+            ->addOption('init-only', null, InputOption::VALUE_NONE, 'Run PHPUnit and Behat initialization only');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -161,6 +162,7 @@ class InstallCommand extends Command
         $factory->dumper     = $this->initializePluginConfigDumper($input);
         $factory->pluginsDir = $pluginsDir;
         $factory->noInit     = $input->getOption('no-init');
+        $factory->initonly   = $input->getOption('init-only');
         $factory->database   = $resolver->resolveDatabase(
             $input->getOption('db-type'),
             $input->getOption('db-name'),

--- a/src/Installer/InstallerFactory.php
+++ b/src/Installer/InstallerFactory.php
@@ -74,12 +74,23 @@ class InstallerFactory
     public $noInit;
 
     /**
+     * @var bool
+     */
+    public $initonly;
+
+    /**
      * Given a big bag of install options, add installers to the collection.
      *
      * @param InstallerCollection $installers Installers will be added to this
      */
     public function addInstallers(InstallerCollection $installers)
     {
+        if ($this->initonly && ($this->plugin->hasBehatFeatures() || $this->plugin->hasUnitTests())) {
+            $installers->add(new TestSuiteInstaller($this->moodle, $this->plugin, $this->execute));
+
+            return;
+        }
+
         $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir));
         $installers->add(new PluginInstaller($this->moodle, $this->plugin, $this->pluginsDir, $this->dumper));
         $installers->add(new VendorInstaller($this->moodle, $this->plugin, $this->execute));


### PR DESCRIPTION
Some plugins can break Moodle installation until a certain patch is applied.
It would be good to be able to split the process into :
1. Run `moodle-plugin-ci install --no-init` to install all environment without initializing test suits.
2. Apply the patch.
3. Run `moodle-plugin-ci install --init-only`  to initialize the Behat and PHPUnit test suites.

