### PR TITLE
Use selenium-firefox docker image version 2.53.1

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -32,10 +32,11 @@ before_install:
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
-  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm selenium/standalone-firefox:3
 
 install:
   - moodle-plugin-ci install
+  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-firefox:2.53.1
+  - sleep 10
 
 script:
   - moodle-plugin-ci phplint

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,21 @@ env:
     - MUSTACHE_IGNORE_NAMES=broken.mustache
     - DB=pgsql
     - MOODLE_BRANCH=master
-    - PROFILE=chrome
 
 install:
   - phpenv config-rm xdebug.ini
   - nvm install 8.9
   - nvm use 8.9
   - make init
-  # Start Selenium Standalone with Chrome/Firefox installed.
-  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm selenium/standalone-${PROFILE}:3
   # Mimic how a Moodle plugin would be run.
   - cp -R tests/Fixture/moodle-local_travis ../moodle-local_travis
   - export PATH="$(cd bin; pwd):$(cd vendor/bin; pwd):$PATH"
   - export TRAVIS_BUILD_DIR=$(cd ../moodle-local_travis; pwd)
-
   # Finally, the standard install step.
   - moodle-plugin-ci install
+  # Start Selenium Standalone with Chrome.
+  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-chrome:3
+  - sleep 10
 
 script:
   - make test-phpunit
@@ -54,7 +53,7 @@ script:
   - moodle-plugin-ci grunt || [ "$MOODLE_BRANCH" != 'master' -a "$MOODLE_BRANCH" != 'MOODLE_38_STABLE' ]
   - moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit --coverage-text
-  - moodle-plugin-ci behat --profile $PROFILE
+  - moodle-plugin-ci behat --profile chrome
 
 jobs:
   include:

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -66,10 +66,6 @@ before_install:
   - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
 # Update the $PATH so scripts from this project can be called easily.
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
-# Start Selenium Standalone server with Chrome/Firefox installed. If you
-# prefer to run Behat tests with Chrome profile (see Behat step details below),
-# use selenium/standalone-chrome:3 image instead.
-  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm selenium/standalone-firefox:3
 
 # This lists steps that are run for installation and setup.
 install:
@@ -84,6 +80,15 @@ install:
 #    - If your plugin has Behat features, then Behat will be setup.
 #    - If your plugin has unit tests, then PHPUnit will be setup.
   - moodle-plugin-ci install
+# Start Selenium Standalone server with Chrome/Firefox installed. If you
+# prefer to run Behat tests with Chrome profile (see Behat step details below),
+# use selenium/standalone-chrome:3 image instead. If you don't run Behat tests,
+# this step is not needed.
+  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-firefox:2.53.1
+# Optional sleep interval, this is important if you run Behat tests as the first
+# step after docker instance creation - in some cases Selenium server might
+# not be ready yet, which will result in failure.
+  - sleep 10
 
 # This lists steps that are run for the purposes of testing.  Any of
 # these steps can be re-ordered or removed to your liking.  And of


### PR DESCRIPTION
Match selenium-firefox version used in https://github.com/moodlehq/moodle-docker (using version 3 will cause failure).

This also adds moodle dir mount to selenium container to allow running file upload
tests (https://github.com/blackboard-open-source/moodle-plugin-ci/issues/110#issuecomment-597576207).

Also remove PROFILE env var in .travis.yml to prevent assumption that
changing its value to `firefox` will work (it won't if version remains 3).