### PR TITLE
Bump local_codechecker to 2.9.6, just released.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_codechecker",
-        "version": "2.9.5",
+        "version": "2.9.6",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
           "type": "git",
-          "reference": "v2.9.5"
+          "reference": "v2.9.6"
         },
         "autoload": {
           "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -254,11 +254,11 @@
         },
         {
             "name": "moodlehq/moodle-local_codechecker",
-            "version": "2.9.5",
+            "version": "2.9.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-                "reference": "v2.9.5"
+                "reference": "v2.9.6"
             },
             "type": "library",
             "autoload": {


### PR DESCRIPTION
Note that these changes, and also the previous #111 are for nothing
unless packagist is refreshed with a new release of moodle-plugin-ci.

Without that everybody continues getting old outdated, components,
like local_codechecker 2.9.3, for example, that is the one corresponding
to the latest version (2.5.0) released @ packagist of moodle-plugin-ci.

Current one is really aging (Feb 2019)!

Link: https://packagist.org/packages/blackboard-open-source/moodle-plugin-ci

And only solution for developers is to use custom repositories and other
non-ideal tricks to get the actual versions installed.